### PR TITLE
feat: remove root_folder for contentLayout

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -557,9 +557,10 @@ export interface AddTorrentOptions {
    */
   paused: TrueFalseStr;
   /**
-   * Create the root folder. Possible values are true, false, unset (default)
+   * Control filesystem structure for content (added in Web API v2.7)
+   * Migrating from rootFolder example rootFolder ? 'Original' :  'NoSubfolder'
    */
-  root_folder: TrueFalseStr;
+  contentLayout: 'Original' | 'Subfolder' | 'NoSubfolder';
   /**
    * Rename torrent
    */


### PR DESCRIPTION
root_folder removed in 4.3.2, but contentLayout has been available since v2.7

BREAKING CHANGE: removes root_folder from add torrent options

fixes #99