### PR TITLE
fix: setTorrentLocation

### DIFF
--- a/src/qbittorrent.ts
+++ b/src/qbittorrent.ts
@@ -282,10 +282,11 @@ export class QBittorrent implements TorrentClient {
    * {@link https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#set-torrent-location}
    */
   async setTorrentLocation(hashes: string | string[] | 'all', location: string): Promise<boolean> {
-    await this.request('/torrents/setLocation', 'POST', undefined, undefined, {
+    const data = {
       location,
       hashes: normalizeHashes(hashes),
-    });
+    };
+    await this.request('/torrents/setLocation', 'POST', undefined, objToUrlSearchParams(data));
     return true;
   }
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -210,10 +210,10 @@ it('should reannounceTorrent', async () => {
   const torrentId = await setupTorrent(client);
   expect(await client.reannounceTorrent(torrentId)).toBeTruthy();
 });
-it.skip('should set torrent location', async () => {
+it('should set torrent location', async () => {
   const client = new QBittorrent({ baseUrl, username, password });
   const torrentId = await setupTorrent(client);
-  const res = await client.setTorrentLocation(torrentId, '/downloads/linux');
+  const res = await client.setTorrentLocation(torrentId, '/tmp');
   expect(res).toBe(true);
 });
 it.skip('should rename file within torrent', async () => {


### PR DESCRIPTION
`setTorrentLocation` is currently broken; as per docs, it should send data in body: https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#set-torrent-location

Also, test is fixed by using `/tmp` directory, which is writeable.