### PR TITLE
feat: Don't delete files by default in removeTorrent

### DIFF
--- a/src/qbittorrent.ts
+++ b/src/qbittorrent.ts
@@ -496,6 +496,7 @@ export class QBittorrent implements TorrentClient {
 
   /**
    * {@link https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#delete-torrents}
+   * @param deleteFiles (default: false) remove files from disk
    */
   async removeTorrent(hashes: string | string[] | 'all', deleteFiles = false): Promise<boolean> {
     const data = {

--- a/src/qbittorrent.ts
+++ b/src/qbittorrent.ts
@@ -497,7 +497,7 @@ export class QBittorrent implements TorrentClient {
   /**
    * {@link https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#delete-torrents}
    */
-  async removeTorrent(hashes: string | string[] | 'all', deleteFiles = true): Promise<boolean> {
+  async removeTorrent(hashes: string | string[] | 'all', deleteFiles = false): Promise<boolean> {
     const data = {
       hashes: normalizeHashes(hashes),
       deleteFiles,


### PR DESCRIPTION
According to the documentation: https://github.com/scttcper/qbittorrent/blob/902228cb2b7e3ae5afdbf69c28c272aea2643154/README.md?plain=1#L68

The `deleteFiles` parameter in `removeTorrent` should default to `false`. I have accidentally removed a few downloaded files using this function 😅 

The other option is to update the docs to reflect the implementation, but I personally believe the default behavior should be the least destructive.