### PR TITLE
docs: fix example code in README for client usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ const client = new QBittorrent({
 });
 
 async function main() {
-  const res = await qbittorrent.getAllData();
+  const res = await client.getAllData();
   console.log(res);
 }
 ```


### PR DESCRIPTION
Fix example code in README: changed `qbittorrent.getAllData()` to `client.getAllData()`.
