### PR TITLE
Add StoppedDL to TorrentState Enum

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -236,6 +236,10 @@ export enum TorrentState {
    */
   Downloading = 'downloading',
   /**
+   * Torrent has been stopped while downloading
+   */
+  StoppedDL = 'stoppedDL',
+  /**
    * Torrent is being downloaded, but no connection were made
    */
   StalledDL = 'stalledDL',


### PR DESCRIPTION
### Description

Add the `StoppedDL` entry to the `TorrentState` enum. I'm sure there are other variations of `Stopped` but I didn't want to create a PR for a value that I haven't observed myself

Value being returned from Postman
![Screenshot 2025-02-12 at 8 13 36 PM](https://github.com/user-attachments/assets/de65c69b-8674-44d3-a77d-d59c638de050)

Torrent as shown in the qBittorrent UI

![image](https://github.com/user-attachments/assets/e95e203c-c66c-484a-ab1d-9eb7ed808cc3)

