### PR TITLE
feat(qbittorrent): Add WebAPI 5.2 endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,10 @@ const client = QBittorrent.createFromState(config, state);
 
 All of the following npm modules provide the same normalized functions along with supporting the unique apis for each client.
 
-- shared types - [@ctrl/shared-torrent](https://github.com/scttcper/shared-torrent)  
-- deluge - [@ctrl/deluge](https://github.com/scttcper/deluge)  
-- transmission - [@ctrl/transmission](https://github.com/scttcper/transmission)  
-- utorrent - [@ctrl/utorrent](https://github.com/scttcper/utorrent)  
+- shared types - [@ctrl/shared-torrent](https://github.com/scttcper/shared-torrent)
+- deluge - [@ctrl/deluge](https://github.com/scttcper/deluge)
+- transmission - [@ctrl/transmission](https://github.com/scttcper/transmission)
+- utorrent - [@ctrl/utorrent](https://github.com/scttcper/utorrent)
 - rtorrent - [@ctrl/rtorrent](https://github.com/scttcper/rtorrent)
 
 ### Start a test docker container
@@ -132,3 +132,30 @@ docker run -d \
   --restart unless-stopped \
   lscr.io/linuxserver/qbittorrent:latest
 ```
+
+### Start a test docker container for qBittorrent alpha
+
+Use the official alpha image when testing against the newest WebAPI changes. The
+linuxserver `latest` image can lag behind the latest qBittorrent release.
+
+```
+mkdir -p /tmp/qbittorrent-alpha/config /tmp/qbittorrent-alpha/downloads
+
+docker run -d \
+  --name=qbittorrent-alpha \
+  -e QBT_LEGAL_NOTICE=confirm \
+  -e QBT_WEBUI_PORT=8080 \
+  -e QBT_TORRENTING_PORT=6881 \
+  -e PUID=1000 \
+  -e PGID=1000 \
+  -p 8080:8080 \
+  -p 6881:6881 \
+  -p 6881:6881/udp \
+  -v /tmp/qbittorrent-alpha/config:/config \
+  -v /tmp/qbittorrent-alpha/downloads:/downloads \
+  qbittorrentofficial/qbittorrent-nox:alpha
+```
+
+The alpha image prints a temporary WebUI password in `docker logs
+qbittorrent-alpha`. Set the WebUI password to `adminadmin` before running the
+integration tests.

--- a/src/qbittorrent.ts
+++ b/src/qbittorrent.ts
@@ -1367,12 +1367,7 @@ function normalizeHashes(hashes: string | string[]): string {
 
 function getAuthCookieName(setCookieHeader: string): string | undefined {
   const [cookiePair] = setCookieHeader.split(';', 1);
-  const cookieName = cookiePair?.split('=', 1)[0];
-  if (cookieName === 'SID' || /^QBT_SID(?:_\d+)?$/.test(cookieName ?? '')) {
-    return cookieName;
-  }
-
-  return undefined;
+  return cookiePair?.split('=', 1)[0];
 }
 
 function assertAddTorrentSucceeded(response: string): void {

--- a/src/qbittorrent.ts
+++ b/src/qbittorrent.ts
@@ -1376,7 +1376,7 @@ function assertAddTorrentSucceeded(response: string): void {
   }
 
   const result = parseAddTorrentResponse(response);
-  if (result && result.success_count === 0 && result.pending_count === 0) {
+  if (result && result.failure_count > 0) {
     throw new Error('Failed to add torrent');
   }
 }

--- a/src/qbittorrent.ts
+++ b/src/qbittorrent.ts
@@ -576,13 +576,13 @@ export class QBittorrent implements TorrentClient {
       form.set('file', new File([torrent], filename, type));
     }
 
-    const res = await this.request<TorrentMetadata[]>(
+    const res = await this.request<TorrentMetadata | TorrentMetadata[]>(
       '/torrents/parseMetadata',
       'POST',
       undefined,
       form,
     );
-    return res;
+    return Array.isArray(res) ? res : [res];
   }
 
   /**

--- a/src/qbittorrent.ts
+++ b/src/qbittorrent.ts
@@ -19,16 +19,28 @@ import { base64ToUint8Array, isUint8Array, stringToUint8Array } from 'uint8array
 import { normalizeTorrentData } from './normalizeTorrentData.js';
 import type {
   AddMagnetOptions,
+  AddTorrentResponse,
   AddTorrentOptions,
   BuildInfo,
+  ClientData,
+  Cookies,
+  DirectoryContent,
+  DirectoryContentMetadata,
+  DirectoryContentOptions,
   DownloadSpeed,
   Preferences,
+  ProcessInfo,
+  RotateApiKeyResponse,
+  SyncMainData,
   Torrent,
   TorrentCategories,
   TorrentFile,
   TorrentFilePriority,
   TorrentFilters,
+  TorrentMetadata,
+  TorrentMetadataRequest,
   TorrentPeersResponse,
+  TorrentPieceAvailability,
   TorrentPieceState,
   TorrentProperties,
   TorrentTrackers,
@@ -43,6 +55,10 @@ interface QBittorrentState extends TorrentClientState {
      */
     sid: string;
     /**
+     * auth cookie name
+     */
+    cookieName?: string;
+    /**
      * cookie expiration
      */
     expires: Date;
@@ -53,7 +69,16 @@ interface QBittorrentState extends TorrentClientState {
   };
 }
 
-const defaults: TorrentClientConfig = {
+export interface QBittorrentConfig extends TorrentClientConfig {
+  /**
+   * qBittorrent WebAPI key. Added in qBittorrent v5.2.0.
+   * When set, the client uses `Authorization: Bearer <apiKey>` instead of cookie login.
+   * {@link https://github.com/qbittorrent/qBittorrent/wiki/API-Key-Authentication-%28%E2%89%A5v5.2.0%29}
+   */
+  apiKey?: string;
+}
+
+const defaults: QBittorrentConfig = {
   baseUrl: 'http://localhost:9091/',
   path: '/api/v2',
   username: '',
@@ -66,7 +91,7 @@ export class QBittorrent implements TorrentClient {
    * Create a new QBittorrent client from a state
    */
   static createFromState(
-    config: Readonly<TorrentClientConfig>,
+    config: Readonly<QBittorrentConfig>,
     state: Readonly<Jsonify<QBittorrentState>>,
   ): QBittorrent {
     const client = new QBittorrent(config);
@@ -77,10 +102,10 @@ export class QBittorrent implements TorrentClient {
     return client;
   }
 
-  config: TorrentClientConfig;
+  config: QBittorrentConfig;
   state: QBittorrentState = {};
 
-  constructor(options: Partial<TorrentClientConfig> = {}) {
+  constructor(options: Partial<QBittorrentConfig> = {}) {
     this.config = { ...defaults, ...options };
   }
 
@@ -142,11 +167,98 @@ export class QBittorrent implements TorrentClient {
   }
 
   /**
+   * Get directory contents.
+   * `withMetadata` was added in qBittorrent WebUI API v2.11.8.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2118}
+   */
+  async getDirectoryContent(
+    dirPath: string,
+    options?: DirectoryContentOptions & { withMetadata?: false },
+  ): Promise<string[]>;
+  async getDirectoryContent(
+    dirPath: string,
+    options: DirectoryContentOptions & { withMetadata: true },
+  ): Promise<DirectoryContentMetadata[]>;
+  async getDirectoryContent(
+    dirPath: string,
+    options: DirectoryContentOptions = {},
+  ): Promise<DirectoryContent> {
+    const params: Record<string, string> = { dirPath };
+    if (options.mode) {
+      params.mode = options.mode;
+    }
+
+    if (options.withMetadata !== undefined) {
+      params.withMetadata = JSON.stringify(options.withMetadata);
+    }
+
+    const res = await this.request<DirectoryContent>('/app/getDirectoryContent', 'GET', params);
+    return res;
+  }
+
+  /**
    * {@link https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-build-info}
    */
   async getBuildInfo(): Promise<BuildInfo> {
     const res = await this.request<BuildInfo>('/app/buildInfo', 'GET');
     return res;
+  }
+
+  /**
+   * Get qBittorrent process info.
+   * Added in qBittorrent WebUI API v2.15.1.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2151}
+   */
+  async getProcessInfo(): Promise<ProcessInfo> {
+    const res = await this.request<ProcessInfo>('/app/processInfo', 'GET');
+    return res;
+  }
+
+  /**
+   * Generate or rotate the WebAPI API key.
+   * Added in qBittorrent WebUI API v2.14.1.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2141}
+   */
+  async rotateApiKey(): Promise<string> {
+    const res = await this.request<RotateApiKeyResponse>('/app/rotateAPIKey', 'POST');
+    return res.apiKey;
+  }
+
+  /**
+   * Delete the existing WebAPI API key.
+   * Added in qBittorrent WebUI API v2.14.1.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2141}
+   */
+  async deleteApiKey(): Promise<boolean> {
+    await this.request('/app/deleteAPIKey', 'POST');
+    return true;
+  }
+
+  /**
+   * Get cookies stored by qBittorrent.
+   * Added in qBittorrent WebUI API v2.11.3.
+   * {@link https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-%28qBittorrent-5.0%29#get-cookies}
+   */
+  async getCookies(): Promise<Cookies> {
+    const res = await this.request<Cookies>('/app/cookies', 'GET');
+    return res;
+  }
+
+  /**
+   * Set cookies stored by qBittorrent.
+   * Added in qBittorrent WebUI API v2.11.3.
+   * {@link https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-%28qBittorrent-5.0%29#set-cookies}
+   */
+  async setCookies(cookies: Cookies): Promise<boolean> {
+    await this.request(
+      '/app/setCookies',
+      'POST',
+      undefined,
+      objToUrlSearchParams({
+        cookies: JSON.stringify(cookies),
+      }),
+    );
+    return true;
   }
 
   async getTorrent(hash: string): Promise<NormalizedTorrent> {
@@ -262,6 +374,7 @@ export class QBittorrent implements TorrentClient {
     limit,
     isPrivate,
     includeTrackers,
+    includeFiles,
   }: {
     hashes?: string | string[];
     filter?: TorrentFilters;
@@ -277,6 +390,12 @@ export class QBittorrent implements TorrentClient {
      */
     isPrivate?: boolean;
     includeTrackers?: boolean;
+    /**
+     * Include torrent files in each returned torrent.
+     * Added in qBittorrent WebUI API v2.11.8.
+     * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2118}
+     */
+    includeFiles?: boolean;
   } = {}): Promise<Torrent[]> {
     const params: Record<string, string> = {};
     if (hashes) {
@@ -332,6 +451,10 @@ export class QBittorrent implements TorrentClient {
       params.includeTrackers = JSON.stringify(includeTrackers);
     }
 
+    if (includeFiles) {
+      params.includeFiles = JSON.stringify(includeFiles);
+    }
+
     const res = await this.request<Torrent[]>('/torrents/info', 'GET', params);
     return res;
   }
@@ -363,6 +486,125 @@ export class QBittorrent implements TorrentClient {
     }
 
     return results;
+  }
+
+  /**
+   * Get sync main data.
+   * {@link https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-%28qBittorrent-5.0%29#get-main-data}
+   */
+  async getSyncMainData(rid?: number): Promise<SyncMainData> {
+    const params: Record<string, number> = {};
+    if (rid !== undefined) {
+      params.rid = rid;
+    }
+
+    const res = await this.request<SyncMainData>('/sync/maindata', 'GET', params);
+    return res;
+  }
+
+  /**
+   * Load data persisted by qBittorrent's WebUI client data API.
+   * Added in qBittorrent WebUI API v2.13.1.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2131}
+   */
+  async loadClientData(keys?: string[]): Promise<ClientData> {
+    const params: Record<string, string> = {};
+    if (keys) {
+      params.keys = JSON.stringify(keys);
+    }
+
+    const res = await this.request<ClientData>('/clientdata/load', 'GET', params);
+    return res;
+  }
+
+  /**
+   * Store data using qBittorrent's WebUI client data API.
+   * Added in qBittorrent WebUI API v2.13.1.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2131}
+   */
+  async storeClientData(data: ClientData): Promise<boolean> {
+    await this.request(
+      '/clientdata/store',
+      'POST',
+      undefined,
+      objToUrlSearchParams({
+        data: JSON.stringify(data),
+      }),
+    );
+    return true;
+  }
+
+  /**
+   * Fetch torrent metadata for a magnet URI, torrent hash, or .torrent URL.
+   * Metadata retrieval can be asynchronous; a partial hash response means retry later.
+   * Added in qBittorrent WebUI API v2.11.9.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2119}
+   */
+  async fetchTorrentMetadata(
+    source: string,
+    options: { downloader?: string } = {},
+  ): Promise<TorrentMetadata | TorrentMetadataRequest> {
+    const params: Record<string, string> = { source };
+    if (options.downloader) {
+      params.downloader = options.downloader;
+    }
+
+    const res = await this.request<TorrentMetadata | TorrentMetadataRequest>(
+      '/torrents/fetchMetadata',
+      'POST',
+      undefined,
+      objToUrlSearchParams(params),
+    );
+    return res;
+  }
+
+  /**
+   * Parse metadata from a .torrent file.
+   * Added in qBittorrent WebUI API v2.11.9. Since v2.13.0 this returns an array
+   * in the same order as the uploaded files.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2119}
+   */
+  async parseTorrentMetadata(
+    torrent: string | Uint8Array<ArrayBuffer>,
+    filename = 'metadata.torrent',
+  ): Promise<TorrentMetadata[]> {
+    const form = new FormData();
+    const type = { type: 'application/x-bittorrent' };
+    if (typeof torrent === 'string') {
+      form.set('file', new File([base64ToUint8Array(torrent)], filename, type));
+    } else {
+      form.set('file', new File([torrent], filename, type));
+    }
+
+    const res = await this.request<TorrentMetadata[]>(
+      '/torrents/parseMetadata',
+      'POST',
+      undefined,
+      form,
+    );
+    return res;
+  }
+
+  /**
+   * Save previously fetched or parsed torrent metadata as a .torrent file.
+   * Added in qBittorrent WebUI API v2.11.9.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2119}
+   */
+  async saveTorrentMetadata(source: string): Promise<Uint8Array<ArrayBuffer>> {
+    await this.ensureAuthenticated('/torrents/saveMetadata');
+
+    const url = joinURL(this.config.baseUrl, this.config.path ?? '', '/torrents/saveMetadata');
+    const res = await ofetch<ArrayBuffer>(url, {
+      method: 'GET',
+      headers: this.authHeaders(),
+      params: { source },
+      retry: 0,
+      timeout: this.config.timeout,
+      responseType: 'arrayBuffer' as 'json',
+      dispatcher: this.config.dispatcher,
+    });
+
+    return new Uint8Array(res);
   }
 
   /**
@@ -433,6 +675,19 @@ export class QBittorrent implements TorrentClient {
   }
 
   /**
+   * Torrents piece availability
+   * @returns an array of availability counts for all pieces (in order) of a specific torrent
+   * Added in qBittorrent WebUI API v2.15.1
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2151}
+   */
+  async torrentPieceAvailability(hash: string): Promise<TorrentPieceAvailability> {
+    const res = await this.request<TorrentPieceAvailability>('/torrents/pieceAvailability', 'GET', {
+      hash,
+    });
+    return res;
+  }
+
+  /**
    * {@link https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#set-torrent-location}
    */
   async setTorrentLocation(hashes: string | string[] | 'all', location: string): Promise<boolean> {
@@ -450,6 +705,20 @@ export class QBittorrent implements TorrentClient {
   async setTorrentName(hash: string, name: string): Promise<boolean> {
     const data = { hash, name };
     await this.request('/torrents/rename', 'POST', undefined, objToUrlSearchParams(data));
+    return true;
+  }
+
+  /**
+   * Set torrent comment.
+   * Added in qBittorrent WebUI API v2.12.1.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2121}
+   */
+  async setTorrentComment(hashes: string | string[] | 'all', comment: string): Promise<boolean> {
+    const data = {
+      hashes: normalizeHashes(hashes),
+      comment,
+    };
+    await this.request('/torrents/setComment', 'POST', undefined, objToUrlSearchParams(data));
     return true;
   }
 
@@ -674,9 +943,15 @@ export class QBittorrent implements TorrentClient {
 
   /**
    * {@link https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#reannounce-torrents}
+   * `trackers` was added in qBittorrent WebUI API v2.11.10.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#21110}
    */
-  async reannounceTorrent(hashes: string | string[] | 'all'): Promise<boolean> {
-    const data = { hashes: normalizeHashes(hashes) };
+  async reannounceTorrent(hashes: string | string[] | 'all', trackers?: string): Promise<boolean> {
+    const data: Record<string, string> = { hashes: normalizeHashes(hashes) };
+    if (trackers) {
+      data.trackers = trackers;
+    }
+
     await this.request('/torrents/reannounce', 'POST', undefined, objToUrlSearchParams(data));
     return true;
   }
@@ -728,9 +1003,7 @@ export class QBittorrent implements TorrentClient {
       false,
     );
 
-    if (res === 'Fails.') {
-      throw new Error('Failed to add torrent');
-    }
+    assertAddTorrentSucceeded(res);
 
     return true;
   }
@@ -847,36 +1120,54 @@ export class QBittorrent implements TorrentClient {
       false,
     );
 
-    if (res === 'Fails.') {
-      throw new Error('Failed to add torrent');
-    }
+    assertAddTorrentSucceeded(res);
 
     return true;
   }
 
   /**
    * {@link https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#add-trackers-to-torrent}
+   * Multiple hashes and `all` were added in qBittorrent WebUI API v2.11.9.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2119}
    */
-  async addTrackers(hash: string, urls: string): Promise<boolean> {
-    const data = { hash, urls };
+  async addTrackers(hash: string | string[] | 'all', urls: string): Promise<boolean> {
+    const data = { hash: normalizeHashes(hash), urls };
     await this.request('/torrents/addTrackers', 'POST', undefined, objToUrlSearchParams(data));
     return true;
   }
 
   /**
    * {@link https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#edit-trackers}
+   * Tracker tier editing was added in qBittorrent WebUI API v2.13.0.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2130}
    */
-  async editTrackers(hash: string, origUrl: string, newUrl: string): Promise<boolean> {
-    const data = { hash, origUrl, newUrl };
+  async editTrackers(
+    hash: string,
+    origUrl: string,
+    newUrl: string,
+    tier?: number,
+  ): Promise<boolean> {
+    const data: Record<string, string | number> = {
+      hash,
+      origUrl,
+      url: origUrl,
+      newUrl,
+    };
+    if (tier !== undefined) {
+      data.tier = tier;
+    }
+
     await this.request('/torrents/editTrackers', 'POST', undefined, objToUrlSearchParams(data));
     return true;
   }
 
   /**
    * {@link https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#remove-trackers}
+   * Multiple hashes and `all` were added in qBittorrent WebUI API v2.11.9.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2119}
    */
-  async removeTrackers(hash: string, urls: string): Promise<boolean> {
-    const data = { hash, urls };
+  async removeTrackers(hash: string | string[] | 'all', urls: string): Promise<boolean> {
+    const data = { hash: normalizeHashes(hash), urls };
     await this.request('/torrents/removeTrackers', 'POST', undefined, objToUrlSearchParams(data));
     return true;
   }
@@ -936,6 +1227,11 @@ export class QBittorrent implements TorrentClient {
    * {@link https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#login}
    */
   async login(): Promise<boolean> {
+    if (this.config.apiKey) {
+      await this.checkVersion();
+      return true;
+    }
+
     const url = joinURL(this.config.baseUrl, this.config.path ?? '', '/auth/login');
 
     const res = await ofetch.raw(url, {
@@ -957,19 +1253,23 @@ export class QBittorrent implements TorrentClient {
       throw new Error('Cookie not found. Auth Failed.');
     }
 
-    const cookie = cookieParse(res.headers.get('set-cookie') ?? '');
-    if (!cookie.SID) {
+    const cookieHeader = res.headers.get('set-cookie') ?? '';
+    const cookieName = getAuthCookieName(cookieHeader);
+    const cookie = cookieParse(cookieHeader);
+    const sid = cookieName ? cookie[cookieName] : undefined;
+    if (!sid) {
       throw new Error('Invalid cookie');
     }
 
     const expires = cookie.Expires ?? cookie.expires;
     const maxAge = cookie['Max-Age'] ?? cookie['max-age'];
     this.state.auth = {
-      sid: cookie.SID,
+      sid,
+      cookieName,
       expires: expires
         ? new Date(expires)
         : maxAge
-          ? new Date(Number(maxAge) * 1000)
+          ? new Date(Date.now() + Number(maxAge) * 1000)
           : new Date(Date.now() + 3_600_000),
     };
 
@@ -993,22 +1293,13 @@ export class QBittorrent implements TorrentClient {
     headers: Record<string, string> = {},
     isJson = true,
   ): Promise<T> {
-    if (
-      !this.state.auth?.sid ||
-      !this.state.auth.expires ||
-      this.state.auth.expires.getTime() < Date.now()
-    ) {
-      const authed = await this.login();
-      if (!authed) {
-        throw new Error('Auth Failed');
-      }
-    }
+    await this.ensureAuthenticated(path);
 
     const url = joinURL(this.config.baseUrl, this.config.path ?? '', path);
     const res = await ofetch<T>(url, {
       method,
       headers: {
-        Cookie: `SID=${this.state.auth!.sid ?? ''}`,
+        ...this.authHeaders(),
         ...headers,
       },
       body,
@@ -1022,6 +1313,31 @@ export class QBittorrent implements TorrentClient {
     });
 
     return res;
+  }
+
+  private async ensureAuthenticated(path: string): Promise<void> {
+    if (this.config.apiKey) {
+      if (!this.state.version?.version && path !== '/app/version') {
+        await this.checkVersion();
+      }
+    } else if (
+      !this.state.auth?.sid ||
+      !this.state.auth.expires ||
+      this.state.auth.expires.getTime() < Date.now()
+    ) {
+      const authed = await this.login();
+      if (!authed) {
+        throw new Error('Auth Failed');
+      }
+    }
+  }
+
+  private authHeaders(): Record<string, string> {
+    if (this.config.apiKey) {
+      return { Authorization: `Bearer ${this.config.apiKey}` };
+    }
+
+    return { Cookie: `${this.state.auth!.cookieName ?? 'SID'}=${this.state.auth!.sid ?? ''}` };
   }
 
   private async checkVersion(): Promise<void> {
@@ -1049,7 +1365,46 @@ function normalizeHashes(hashes: string | string[]): string {
   return hashes;
 }
 
-function objToUrlSearchParams(obj: Record<string, string | boolean>): URLSearchParams {
+function getAuthCookieName(setCookieHeader: string): string | undefined {
+  const [cookiePair] = setCookieHeader.split(';', 1);
+  const cookieName = cookiePair?.split('=', 1)[0];
+  if (cookieName === 'SID' || /^QBT_SID(?:_\d+)?$/.test(cookieName ?? '')) {
+    return cookieName;
+  }
+
+  return undefined;
+}
+
+function assertAddTorrentSucceeded(response: string): void {
+  if (response === 'Fails.') {
+    throw new Error('Failed to add torrent');
+  }
+
+  const result = parseAddTorrentResponse(response);
+  if (result && result.success_count === 0 && result.pending_count === 0) {
+    throw new Error('Failed to add torrent');
+  }
+}
+
+function parseAddTorrentResponse(response: string): AddTorrentResponse | undefined {
+  try {
+    const parsed = JSON.parse(response) as Partial<AddTorrentResponse>;
+    if (
+      typeof parsed.success_count === 'number' &&
+      typeof parsed.pending_count === 'number' &&
+      typeof parsed.failure_count === 'number' &&
+      Array.isArray(parsed.added_torrent_ids)
+    ) {
+      return parsed as AddTorrentResponse;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+function objToUrlSearchParams(obj: Record<string, string | number | boolean>): URLSearchParams {
   const params = new URLSearchParams();
   for (const [key, value] of Object.entries(obj)) {
     params.append(key, value.toString());

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,232 @@ export interface BuildInfo {
   /**
    * Application bitness (e.g. 64-bit)
    */
-  bitness: string;
+  bitness: number;
+}
+
+export interface ProcessInfo {
+  /**
+   * Process launch time as UTC epoch seconds
+   * Added in qBittorrent WebUI API v2.15.1
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2151}
+   */
+  launch_time: number;
+}
+
+export interface RotateApiKeyResponse {
+  /**
+   * Generated WebAPI API key.
+   * Added in qBittorrent WebUI API v2.14.1
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2141}
+   */
+  apiKey: string;
+}
+
+export interface Cookie {
+  /**
+   * Cookie name
+   */
+  name: string;
+  /**
+   * Cookie domain
+   */
+  domain: string;
+  /**
+   * Cookie path
+   */
+  path: string;
+  /**
+   * Cookie value
+   */
+  value: string;
+  /**
+   * Cookie expiration time as UTC epoch seconds
+   */
+  expirationDate: number;
+}
+
+export type Cookies = Cookie[];
+
+/**
+ * Data stored by qBittorrent's WebUI client data API.
+ * Added in qBittorrent WebUI API v2.13.1
+ * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2131}
+ */
+export type ClientData = Record<string, unknown>;
+
+/**
+ * Visibility filter for /app/getDirectoryContent.
+ * qBittorrent accepts `all`, `dirs`, and `files`.
+ */
+export type DirectoryContentMode = 'all' | 'dirs' | 'files';
+
+export interface DirectoryContentOptions {
+  mode?: DirectoryContentMode;
+  /**
+   * Include filesystem metadata in /app/getDirectoryContent response.
+   * Added in qBittorrent WebUI API v2.11.8
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2118}
+   */
+  withMetadata?: boolean;
+}
+
+export interface DirectoryContentMetadata {
+  /**
+   * File or directory name
+   */
+  name: string;
+  /**
+   * Entry type returned by qBittorrent, e.g. file or directory
+   */
+  type: string;
+  /**
+   * File size in bytes
+   */
+  size: number;
+  /**
+   * Creation time as UTC epoch seconds
+   */
+  creation_date: number;
+  /**
+   * Last access time as UTC epoch seconds
+   */
+  last_access_date: number;
+  /**
+   * Last modification time as UTC epoch seconds
+   */
+  last_modification_date: number;
+}
+
+export type DirectoryContent = string[] | DirectoryContentMetadata[];
+
+export interface AddTorrentResponse {
+  /**
+   * Number of torrents successfully added.
+   * Added in qBittorrent WebUI API v2.14.0
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2140}
+   */
+  success_count: number;
+  /**
+   * Number of torrents queued for asynchronous metadata fetching.
+   * Added in qBittorrent WebUI API v2.14.0
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2140}
+   */
+  pending_count: number;
+  /**
+   * Number of torrents that failed to add.
+   * Added in qBittorrent WebUI API v2.14.0
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2140}
+   */
+  failure_count: number;
+  /**
+   * Torrent IDs for successfully added torrents.
+   * Added in qBittorrent WebUI API v2.14.0
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2140}
+   */
+  added_torrent_ids: string[];
+}
+
+export interface TorrentMetadataFile {
+  /**
+   * File path inside the torrent
+   */
+  path: string;
+  /**
+   * File size in bytes
+   */
+  length: number;
+}
+
+export interface TorrentMetadataInfo {
+  /**
+   * Torrent file list
+   */
+  files: TorrentMetadataFile[];
+  /**
+   * Total torrent size in bytes
+   */
+  length: number;
+  /**
+   * Torrent name
+   */
+  name: string;
+  /**
+   * Torrent piece length in bytes
+   */
+  piece_length: number;
+  /**
+   * Number of pieces in the torrent
+   */
+  pieces_num: number;
+  /**
+   * True if this is a private torrent
+   */
+  private: boolean;
+}
+
+export interface TorrentMetadataTracker {
+  /**
+   * Tracker URL
+   */
+  url: string;
+  /**
+   * Tracker tier
+   */
+  tier: number;
+}
+
+export interface TorrentMetadata {
+  /**
+   * Torrent comment
+   */
+  comment: string;
+  /**
+   * Torrent creator
+   */
+  created_by: string;
+  /**
+   * Torrent creation date as UTC epoch seconds
+   */
+  creation_date: number;
+  /**
+   * Torrent ID
+   */
+  hash: string;
+  /**
+   * v1 info hash, or empty string for v2-only torrents
+   */
+  infohash_v1: string;
+  /**
+   * v2 info hash, or empty string for v1-only torrents
+   */
+  infohash_v2: string;
+  /**
+   * Torrent metadata
+   */
+  info: TorrentMetadataInfo;
+  /**
+   * Torrent trackers
+   */
+  trackers: TorrentMetadataTracker[];
+  /**
+   * Torrent web seed URLs
+   */
+  webseeds: string[];
+}
+
+export interface TorrentMetadataRequest {
+  /**
+   * Torrent ID, if available while metadata is still being fetched
+   */
+  hash?: string;
+  /**
+   * v1 info hash, if available while metadata is still being fetched
+   */
+  infohash_v1?: string;
+  /**
+   * v2 info hash, if available while metadata is still being fetched
+   */
+  infohash_v2?: string;
 }
 
 /**
@@ -222,6 +447,11 @@ export interface Torrent {
    */
   force_start: boolean;
   /**
+   * Torrent creation datetime in seconds
+   * Added in qBittorrent v5.2.0
+   */
+  created_on?: number;
+  /**
    * True if torrent is from a private tracker
    * Added in qBittorrent v5.0.0
    * Might be able to make not optional once qb v5 is more widely used
@@ -237,12 +467,72 @@ export interface Torrent {
    * Added in qBittorrent WebUI API v2.8.1
    */
   seeding_time: number;
+  /**
+   * Included when `includeFiles` is passed to /torrents/info
+   * Added in qBittorrent WebUI API v2.11.8
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2118}
+   */
+  files?: TorrentFile[];
+  /**
+   * True when at least one tracker has a warning
+   * Added in qBittorrent WebUI API v2.11.7
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2117}
+   */
+  has_tracker_warning?: boolean;
+  /**
+   * True when at least one tracker has an error
+   * Added in qBittorrent WebUI API v2.11.7
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2117}
+   */
+  has_tracker_error?: boolean;
+  /**
+   * True when the torrent has a non-tracker announce error
+   * Added in qBittorrent WebUI API v2.11.7
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2117}
+   */
+  has_other_announce_error?: boolean;
+  /**
+   * Share limit action for this torrent
+   * Added in qBittorrent WebUI API v2.12.0
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2120}
+   */
+  share_limit_action?: string;
 }
 
 export type TorrentCategories = Record<string, Category>;
 interface Category {
   name: string;
   savePath: string;
+  /**
+   * Category download path. Added in qBittorrent WebUI API v2.12.1
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2121}
+   */
+  download_path?: string | null;
+  /**
+   * Category share ratio limit. Added in qBittorrent WebUI API v2.12.0
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2120}
+   */
+  ratio_limit?: number;
+  /**
+   * Category seeding time limit. Added in qBittorrent WebUI API v2.12.0
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2120}
+   */
+  seeding_time_limit?: number;
+  /**
+   * Category inactive seeding time limit. Added in qBittorrent WebUI API v2.15.0
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2150}
+   */
+  inactive_seeding_time_limit?: number;
+  /**
+   * Category share limit action. Added in qBittorrent WebUI API v2.12.0
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2120}
+   */
+  share_limit_action?: string;
+  /**
+   * Category share limit mode. Added in qBittorrent WebUI API v2.12.0
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2120}
+   */
+  share_limits_mode?: string;
 }
 
 export enum TorrentState {
@@ -504,9 +794,74 @@ export interface TorrentTrackers {
    */
   num_downloaded: number;
   /**
+   * Seconds until next announce
+   * Added in qBittorrent WebUI API v2.13.0
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2130}
+   */
+  next_announce?: number;
+  /**
+   * Minimum seconds until next announce
+   * Added in qBittorrent WebUI API v2.13.0
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2130}
+   */
+  min_announce?: number;
+  /**
+   * Tracker endpoint announce statistics
+   * Added in qBittorrent WebUI API v2.13.0
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2130}
+   */
+  endpoints?: TorrentTrackerEndpoint[];
+  /**
    * Tracker message (there is no way of knowing what this message is - it's up to tracker admins)
    */
   msg: string;
+}
+
+export interface TorrentTrackerEndpoint {
+  /**
+   * Tracker endpoint name
+   */
+  name: string;
+  /**
+   * True if this endpoint is currently announcing
+   */
+  updating: boolean;
+  /**
+   * Tracker endpoint status. See TorrentTrackerStatus.
+   */
+  status: TorrentTrackerStatus;
+  /**
+   * Tracker endpoint message
+   */
+  msg: string;
+  /**
+   * BitTorrent protocol version used by this endpoint
+   */
+  bt_version: string;
+  /**
+   * Number of peers reported by this endpoint
+   */
+  num_peers: number;
+  /**
+   * Number of seeds reported by this endpoint
+   */
+  num_seeds: number;
+  /**
+   * Number of leeches reported by this endpoint
+   */
+  num_leeches: number;
+  /**
+   * Number of completed downloads reported by this endpoint
+   */
+  num_downloaded: number;
+  /**
+   * Seconds until next announce
+   */
+  next_announce: number;
+  /**
+   * Minimum seconds until next announce
+   */
+  min_announce: number;
 }
 
 export enum TorrentTrackerStatus {
@@ -530,6 +885,14 @@ export enum TorrentTrackerStatus {
    * Tracker has been contacted, but it is not working (or doesn't send proper replies)
    */
   Errored = 4,
+  /**
+   * Tracker error
+   */
+  TrackerError = 5,
+  /**
+   * Tracker is unreachable
+   */
+  Unreachable = 6,
 }
 
 export interface WebSeed {
@@ -604,6 +967,8 @@ export enum TorrentPieceState {
   Downloaded = 2,
 }
 
+export type TorrentPieceAvailability = number[];
+
 type TrueFalseStr = 'true' | 'false';
 
 export interface AddTorrentOptions {
@@ -673,6 +1038,12 @@ export interface AddTorrentOptions {
    * Prioritize download first last piece. Possible values are true, false (default)
    */
   firstLastPiecePrio: TrueFalseStr;
+  /**
+   * File priorities when adding a single torrent from previously fetched or parsed metadata.
+   * Added in qBittorrent WebUI API v2.11.9
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2119}
+   */
+  filePriorities: string | TorrentFilePriority[];
 }
 
 export interface AddMagnetOptions {
@@ -723,6 +1094,18 @@ export interface AddMagnetOptions {
    * Prioritize download first last piece. Possible values are true, false (default)
    */
   firstLastPiecePrio: TrueFalseStr;
+  /**
+   * Search plugin used to download the torrent.
+   * Added to /torrents/add in qBittorrent WebUI API v2.13.1
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2131}
+   */
+  downloader: string;
+  /**
+   * File priorities when adding a single torrent from previously fetched or parsed metadata.
+   * Added in qBittorrent WebUI API v2.11.9
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2119}
+   */
+  filePriorities: string | TorrentFilePriority[];
 }
 
 export interface Preferences {
@@ -1295,6 +1678,12 @@ export interface Preferences {
    */
   resolve_peer_countries: boolean;
   /**
+   * True resolves peer host names
+   * Added in qBittorrent WebUI API v2.15.1
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2151}
+   */
+  resolve_peer_host_names?: boolean;
+  /**
    * Save resume data interval in min
    */
   save_resume_data_interval: number;
@@ -1330,6 +1719,11 @@ export interface Preferences {
    * μTP-TCP mixed mode algorithm (see list of possible values below)
    */
   utp_tcp_mixed_mode: number;
+  /**
+   * Hostname resolver cache expiry interval in seconds
+   * Added in qBittorrent v5.2.0
+   */
+  hostname_cache_ttl?: number;
 }
 
 export interface TorrentPeersResponse {
@@ -1351,6 +1745,18 @@ export interface TorrentPeer {
   files?: string;
   flags?: string;
   flags_desc?: string;
+  /**
+   * Resolved peer host name
+   * Added in qBittorrent WebUI API v2.15.1
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2151}
+   */
+  host_name?: string;
+  /**
+   * I2P destination for I2P peers. When present, `ip` and `port` are omitted.
+   * Added in qBittorrent WebUI API v2.13.0
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2130}
+   */
+  i2p_dest?: string;
   ip?: string;
   port?: number;
   progress?: number;
@@ -1362,3 +1768,35 @@ export interface TorrentPeer {
 export type DownloadSpeed = Record<string, number>;
 
 export type UploadSpeed = Record<string, number>;
+
+export interface SyncMainData {
+  /**
+   * Response ID
+   */
+  rid: number;
+  /**
+   * True when the response contains full data instead of a delta update
+   */
+  full_update: boolean;
+  /**
+   * Torrent updates keyed by torrent hash
+   */
+  torrents?: Record<string, Partial<Torrent>>;
+  /**
+   * Hashes for torrents removed since the previous response ID
+   */
+  torrents_removed?: string[];
+  categories?: TorrentCategories;
+  categories_removed?: string[];
+  tags?: string[];
+  tags_removed?: string[];
+  server_state?: Record<string, unknown>;
+  /**
+   * Tracker URLs grouped by tracker status
+   * Added in qBittorrent WebUI API v2.13.0
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2130}
+   */
+  trackers?: Record<string, string[]>;
+  trackers_removed?: string[];
+  [key: string]: unknown;
+}

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -15,6 +15,22 @@ const username = 'admin';
 const password = 'adminadmin';
 const magnet =
   'magnet:?xt=urn:btih:B0B81206633C42874173D22E564D293DAEFC45E2&dn=Ubuntu+11+10+Alternate+Amd64+Iso&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969%2Fannounce&tr=udp%3A%2F%2F9.rarbg.to%3A2710%2Fannounce&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.open-internet.nl%3A6969%2Fannounce&tr=udp%3A%2F%2Fopen.demonii.si%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.pirateparty.gr%3A6969%2Fannounce&tr=udp%3A%2F%2Fdenis.stalker.upeer.me%3A6969%2Fannounce&tr=udp%3A%2F%2Fp4p.arenabg.com%3A1337%2Fannounce&tr=udp%3A%2F%2Fexodus.desync.com%3A6969%2Fannounce';
+let apiVersionPromise: Promise<string> | undefined;
+
+function getTestApiVersion(): Promise<string> {
+  apiVersionPromise ??= new QBittorrent({ baseUrl, username, password }).getApiVersion();
+  return apiVersionPromise;
+}
+
+async function skipIfUnsupported(minVersion: string, feature: string): Promise<boolean> {
+  const apiVersion = await getTestApiVersion();
+  if (isVersionGreaterOrEqual(apiVersion, minVersion)) {
+    return false;
+  }
+
+  console.log(`Skipping ${feature}: WebAPI ${apiVersion} < ${minVersion}`);
+  return true;
+}
 
 async function waitForTorrent(client: QBittorrent) {
   await pWaitFor(
@@ -35,6 +51,10 @@ async function setupTorrent(client: QBittorrent): Promise<string> {
   await waitForTorrent(client);
   const torrents = await client.listTorrents();
   return torrents[0]!.hash;
+}
+
+function isVersionGreaterOrEqual(version: string, minVersion: string): boolean {
+  return version.localeCompare(minVersion, undefined, { numeric: true }) >= 0;
 }
 
 afterEach(async () => {
@@ -184,6 +204,58 @@ it('should get torrent piece hashes', async () => {
   const res = await client.torrentPieceHashes(torrentId);
   expect(res.length).toBe(3726);
 });
+it('should get torrent piece availability', async () => {
+  if (await skipIfUnsupported('2.15.1', 'torrent piece availability')) {
+    return;
+  }
+
+  const client = new QBittorrent({ baseUrl, username, password });
+  const torrentId = await setupTorrent(client);
+  const res = await client.torrentPieceAvailability(torrentId);
+  expect(res.length).toBe(3726);
+  expect(res.every(piece => typeof piece === 'number')).toBe(true);
+});
+it('should fetch torrent metadata', async () => {
+  if (await skipIfUnsupported('2.11.9', 'fetch torrent metadata')) {
+    return;
+  }
+
+  const client = new QBittorrent({ baseUrl, username, password });
+  const torrentId = await setupTorrent(client);
+  const metadata = await client.fetchTorrentMetadata(torrentId);
+  expect(metadata.hash).toBe(torrentId);
+  expect('info' in metadata ? metadata.info.name : undefined).toBe(torrentName);
+});
+it('should parse and save torrent metadata', async () => {
+  if (await skipIfUnsupported('2.11.9', 'parse and save torrent metadata')) {
+    return;
+  }
+
+  const client = new QBittorrent({ baseUrl, username, password });
+  const [metadata] = await client.parseTorrentMetadata(torrentFileBuffer, 'ubuntu.torrent');
+  expect(metadata!.hash).toBe('e84213a794f3ccd890382a54a64ca68b7e925433');
+  expect(metadata!.info.files[0]!.path).toBe('ubuntu-18.04.1-desktop-amd64.iso');
+
+  const torrent = await client.saveTorrentMetadata(metadata!.hash);
+  expect(torrent.byteLength).toBeGreaterThan(0);
+});
+it('should add torrent from parsed metadata with file priorities', async () => {
+  if (await skipIfUnsupported('2.11.9', 'add torrent from parsed metadata')) {
+    return;
+  }
+
+  const client = new QBittorrent({ baseUrl, username, password });
+  const [metadata] = await client.parseTorrentMetadata(torrentFileBuffer, 'ubuntu.torrent');
+  const res = await client.addMagnet(metadata!.hash, {
+    filePriorities: [TorrentFilePriority.Skip],
+    stopped: 'true',
+  });
+  expect(res).toBe(true);
+  await waitForTorrent(client);
+
+  const files = await client.torrentFiles(metadata!.hash);
+  expect(files[0]!.priority).toBe(TorrentFilePriority.Skip);
+});
 it('should add/remove torrent tag', async () => {
   const client = new QBittorrent({ baseUrl, username, password });
   const torrentId = await setupTorrent(client);
@@ -220,7 +292,10 @@ it('should rename file within torrent', async () => {
   const torrentId = await setupTorrent(client);
   let torrentFiles = await client.torrentFiles(torrentId);
   expect(await client.renameFile(torrentId, torrentFiles[0]!.name, 'ubuntu')).toBe(true);
-  torrentFiles = await client.torrentFiles(torrentId);
+  await pWaitFor(async () => {
+    torrentFiles = await client.torrentFiles(torrentId);
+    return torrentFiles[0]?.name === 'ubuntu';
+  });
   expect(torrentFiles[0]!.name).toBe('ubuntu');
 });
 it('should set torrent priority', async () => {
@@ -313,14 +388,15 @@ it('should set preferences', async () => {
 });
 it('should get / create / edit / remove category', async () => {
   const client = new QBittorrent({ baseUrl, username, password });
+  await client.removeCategory('movie');
   let categories = await client.getCategories();
   expect(categories.movie).toBe(undefined);
   await client.createCategory('movie', '/data');
   categories = await client.getCategories();
-  expect(categories.movie).toEqual({ name: 'movie', savePath: '/data' });
+  expect(categories.movie).toMatchObject({ name: 'movie', savePath: '/data' });
   await client.editCategory('movie', '/swag');
   categories = await client.getCategories();
-  expect(categories.movie).toEqual({ name: 'movie', savePath: '/swag' });
+  expect(categories.movie).toMatchObject({ name: 'movie', savePath: '/swag' });
   await client.removeCategory('movie');
   categories = await client.getCategories();
   expect(categories.movie).toBe(undefined);
@@ -367,6 +443,97 @@ it('should get build info', async () => {
   const buildInfo = await client.getBuildInfo();
   expect(buildInfo.libtorrent).toBeTruthy();
   expect(typeof buildInfo.libtorrent).toBe('string');
+});
+it('should get process info', async () => {
+  if (await skipIfUnsupported('2.15.1', 'process info')) {
+    return;
+  }
+
+  const client = new QBittorrent({ baseUrl, username, password });
+  const processInfo = await client.getProcessInfo();
+  expect(processInfo.launch_time).toBeGreaterThan(0);
+});
+it('should get directory content metadata', async () => {
+  if (await skipIfUnsupported('2.11.8', 'directory content metadata')) {
+    return;
+  }
+
+  const client = new QBittorrent({ baseUrl, username, password });
+  const content = await client.getDirectoryContent('/downloads', { withMetadata: true });
+  expect(Array.isArray(content)).toBe(true);
+});
+it('should list torrents with included files', async () => {
+  if (await skipIfUnsupported('2.11.8', 'torrent list included files')) {
+    return;
+  }
+
+  const client = new QBittorrent({ baseUrl, username, password });
+  await setupTorrent(client);
+  const torrents = await client.listTorrents({ includeFiles: true });
+  expect(torrents[0]!.files?.map(file => file.name)).includes('ubuntu-18.04.1-desktop-amd64.iso');
+});
+it('should set torrent comment', async () => {
+  if (await skipIfUnsupported('2.12.1', 'torrent comments')) {
+    return;
+  }
+
+  const client = new QBittorrent({ baseUrl, username, password });
+  const torrentId = await setupTorrent(client);
+  expect(await client.setTorrentComment(torrentId, 'important comment')).toBe(true);
+  const properties = await client.torrentProperties(torrentId);
+  expect(properties.comment).toBe('important comment');
+});
+it('should get sync main data', async () => {
+  const client = new QBittorrent({ baseUrl, username, password });
+  const data = await client.getSyncMainData();
+  expect(data.full_update).toBe(true);
+  expect(data.rid).toBeGreaterThan(0);
+});
+it('should store and load client data', async () => {
+  if (await skipIfUnsupported('2.13.1', 'client data')) {
+    return;
+  }
+
+  const client = new QBittorrent({ baseUrl, username, password });
+  await client.storeClientData({ test_value: 'stored' });
+  const data = await client.loadClientData(['test_value']);
+  expect(data.test_value).toBe('stored');
+});
+it('should get and set cookies', async () => {
+  const client = new QBittorrent({ baseUrl, username, password });
+  await client.setCookies([
+    {
+      name: 'test_cookie',
+      domain: 'example.com',
+      path: '/',
+      value: 'stored',
+      expirationDate: Math.floor(Date.now() / 1000) + 3600,
+    },
+  ]);
+  const cookies = await client.getCookies();
+  expect(cookies).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: 'test_cookie',
+        value: 'stored',
+      }),
+    ]),
+  );
+});
+it('should authenticate with api key', async () => {
+  if (await skipIfUnsupported('2.14.1', 'api key auth')) {
+    return;
+  }
+
+  const client = new QBittorrent({ baseUrl, username, password });
+  const apiKey = await client.rotateApiKey();
+  expect(apiKey).toMatch(/^qbt_/);
+
+  const apiKeyClient = new QBittorrent({ baseUrl, apiKey });
+  const version = await apiKeyClient.getAppVersion();
+  expect(version).toBeTruthy();
+
+  await client.deleteApiKey();
 });
 it('should set torrent name', async () => {
   const client = new QBittorrent({ baseUrl, username, password });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -500,6 +500,10 @@ it('should store and load client data', async () => {
   expect(data.test_value).toBe('stored');
 });
 it('should get and set cookies', async () => {
+  if (await skipIfUnsupported('2.11.3', 'cookies')) {
+    return;
+  }
+
   const client = new QBittorrent({ baseUrl, username, password });
   await client.setCookies([
     {


### PR DESCRIPTION
qBittorrent 5.2 added a bunch of WebAPI surface around metadata workflows, directory metadata, API keys, cookies, and richer torrent/app state. This exposes those from the client and adds helpful types linked back to the official docs/changelog where it matters.

Also updates the integration tests so newer endpoints are version-gated. The older Docker image still passes CI, while the alpha image actually exercises the new endpoints.