### PR TITLE
ref(qbittorrent): Reuse torrent file upload helper

### DIFF
--- a/src/addTorrentForm.ts
+++ b/src/addTorrentForm.ts
@@ -31,13 +31,8 @@ export function buildAddTorrentForm({
   if (source.type === 'magnet') {
     form.append('urls', source.urls);
   } else {
-    const type = { type: 'application/x-bittorrent' };
     const fileName = filename ?? (typeof source.torrent === 'string' ? 'file.torrent' : 'torrent');
-    const file =
-      typeof source.torrent === 'string'
-        ? new File([base64ToUint8Array(source.torrent)], fileName, type)
-        : new File([source.torrent], fileName, type);
-    form.set('file', file);
+    form.set('file', createTorrentFile(source.torrent, fileName));
   }
 
   for (const [key, value] of Object.entries(fields)) {
@@ -47,6 +42,18 @@ export function buildAddTorrentForm({
   }
 
   return form;
+}
+
+export function createTorrentFile(
+  torrent: string | Uint8Array<ArrayBuffer>,
+  filename: string,
+): File {
+  const type = { type: 'application/x-bittorrent' };
+  if (typeof torrent === 'string') {
+    return new File([base64ToUint8Array(torrent)], filename, type);
+  }
+
+  return new File([torrent], filename, type);
 }
 
 function normalizeAddTorrentFormOptions(

--- a/src/qbittorrent.ts
+++ b/src/qbittorrent.ts
@@ -10,9 +10,9 @@ import type {
 import { hash as torrentFileHash } from '@ctrl/torrent-file';
 import { FormData } from 'node-fetch-native';
 import type { Jsonify } from 'type-fest';
-import { base64ToUint8Array, isUint8Array, stringToUint8Array } from 'uint8array-extras';
+import { isUint8Array, stringToUint8Array } from 'uint8array-extras';
 
-import { buildAddTorrentForm } from './addTorrentForm.js';
+import { buildAddTorrentForm, createTorrentFile } from './addTorrentForm.js';
 import { normalizeTorrentData } from './normalizeTorrentData.js';
 import { QBittorrentSession, type QBittorrentState } from './qbittorrentSession.js';
 import {
@@ -533,12 +533,7 @@ export class QBittorrent extends QBittorrentSession implements TorrentClient {
     filename = 'metadata.torrent',
   ): Promise<TorrentMetadata[]> {
     const form = new FormData();
-    const type = { type: 'application/x-bittorrent' };
-    if (typeof torrent === 'string') {
-      form.set('file', new File([base64ToUint8Array(torrent)], filename, type));
-    } else {
-      form.set('file', new File([torrent], filename, type));
-    }
+    form.set('file', createTorrentFile(torrent, filename));
 
     const res = await this.request<TorrentMetadata | TorrentMetadata[]>(
       '/torrents/parseMetadata',


### PR DESCRIPTION
keep the `.torrent` File construction in one place so add torrent and metadata parsing don't drift apart.