### PR TITLE
feat(qbittorrent): Add basic auth fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,23 +19,43 @@ jobs:
           node-version: 24
 
       - name: start qbittorrent
-        # creates a default config with password adminadmin
         run: |
-          mkdir -p ~/.config/qBittorrent/
-          cat > ~/.config/qBittorrent/qBittorrent.conf << 'EOF'
+          mkdir -p /tmp/qbittorrent/config/qBittorrent/config /tmp/qbittorrent/downloads
+          cat > /tmp/qbittorrent/config/qBittorrent/config/qBittorrent.conf << 'EOF'
           [BitTorrent]
+          Session\DefaultSavePath=/downloads
+          Session\Port=6881
           Session\QueueingSystemEnabled=false
+          Session\TempPath=/downloads/temp
+
           [Meta]
           MigrationVersion=6
+
           [Preferences]
           WebUI\Password_PBKDF2="@ByteArray(ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ==)"
+          WebUI\Port=8080
           EOF
-          sudo add-apt-repository ppa:qbittorrent-team/qbittorrent-stable
-          sudo apt update
-          sudo apt install qbittorrent-nox
-          qbittorrent-nox -d
-          sudo mkdir /downloads
-          mkdir ~/downloads
+          docker run -d \
+            --name qbittorrent \
+            -e QBT_LEGAL_NOTICE=confirm \
+            -e QBT_WEBUI_PORT=8080 \
+            -e QBT_TORRENTING_PORT=6881 \
+            -e PUID="$(id -u)" \
+            -e PGID="$(id -g)" \
+            -p 8080:8080 \
+            -p 6881:6881 \
+            -p 6881:6881/udp \
+            -v /tmp/qbittorrent/config:/config \
+            -v /tmp/qbittorrent/downloads:/downloads \
+            qbittorrentofficial/qbittorrent-nox:alpha
+          for i in {1..30}; do
+            if curl -fsS -u admin:adminadmin http://localhost:8080/api/v2/app/version; then
+              exit 0
+            fi
+            sleep 2
+          done
+          docker logs qbittorrent
+          exit 1
 
       - name: lint
         run: pnpm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
 
       - name: start qbittorrent
         run: |
+          # The official image stores config under /config/qBittorrent/config.
+          # Use the alpha image so CI covers WebAPI 2.14.1+ auth behavior
+          # including Basic auth on API requests and API key endpoints.
           mkdir -p /tmp/qbittorrent/config/qBittorrent/config /tmp/qbittorrent/downloads
           cat > /tmp/qbittorrent/config/qBittorrent/config/qBittorrent.conf << 'EOF'
           [BitTorrent]

--- a/src/qbittorrentSession.ts
+++ b/src/qbittorrentSession.ts
@@ -36,6 +36,15 @@ export interface QBittorrentConfig extends TorrentClientConfig {
   apiKey?: string;
 }
 
+type RequestOptions = {
+  path: string;
+  method: 'GET' | 'POST';
+  params?: Record<string, string | number>;
+  body?: URLSearchParams | FormData;
+  headers?: Record<string, string>;
+  responseType?: 'arrayBuffer' | 'json' | 'text';
+};
+
 const defaults: QBittorrentConfig = {
   baseUrl: 'http://localhost:9091/',
   path: '/api/v2',
@@ -129,46 +138,26 @@ export class QBittorrentSession {
     headers: Record<string, string> = {},
     isJson = true,
   ): Promise<T> {
-    await this.ensureAuthenticated(path);
-
-    const url = joinURL(this.config.baseUrl, this.config.path ?? '', path);
-    const res = await ofetch<T>(url, {
+    return this.requestWithAuth<T>({
+      path,
       method,
-      headers: {
-        ...this.authHeaders(),
-        ...headers,
-      },
-      body,
       params,
-      retry: 0,
-      timeout: this.config.timeout,
-      // casting to json to avoid type error
-      responseType: isJson ? 'json' : ('text' as 'json'),
-      // allow proxy agent
-      dispatcher: this.config.dispatcher,
+      body,
+      headers,
+      responseType: isJson ? 'json' : 'text',
     });
-
-    return res;
   }
 
   async requestArrayBuffer(
     path: string,
     params?: Record<string, string | number>,
   ): Promise<ArrayBuffer> {
-    await this.ensureAuthenticated(path);
-
-    const url = joinURL(this.config.baseUrl, this.config.path ?? '', path);
-    const res = await ofetch<ArrayBuffer>(url, {
+    return this.requestWithAuth<ArrayBuffer>({
+      path,
       method: 'GET',
-      headers: this.authHeaders(),
       params,
-      retry: 0,
-      timeout: this.config.timeout,
-      responseType: 'arrayBuffer' as 'json',
-      dispatcher: this.config.dispatcher,
+      responseType: 'arrayBuffer',
     });
-
-    return res;
   }
 
   protected async ensureAuthenticated(path: string): Promise<void> {
@@ -193,7 +182,63 @@ export class QBittorrentSession {
       return { Authorization: `Bearer ${this.config.apiKey}` };
     }
 
-    return { Cookie: `${this.state.auth!.cookieName ?? 'SID'}=${this.state.auth!.sid ?? ''}` };
+    const headers: Record<string, string> = {
+      Cookie: `${this.state.auth!.cookieName ?? 'SID'}=${this.state.auth!.sid ?? ''}`,
+    };
+    const basicAuth = this.basicAuthHeader();
+    if (basicAuth) {
+      headers.Authorization = basicAuth;
+    }
+
+    return headers;
+  }
+
+  protected basicAuthHeader(): string | undefined {
+    if (!this.config.username && !this.config.password) {
+      return undefined;
+    }
+
+    const credentials = Buffer.from(`${this.config.username ?? ''}:${this.config.password ?? ''}`);
+    return `Basic ${credentials.toString('base64')}`;
+  }
+
+  private async requestWithAuth<T>(options: RequestOptions): Promise<T> {
+    try {
+      return await this.requestOnce<T>(options);
+    } catch (error) {
+      if (this.config.apiKey || !isAuthError(error)) {
+        throw error;
+      }
+
+      delete this.state.auth;
+      return this.requestOnce<T>(options);
+    }
+  }
+
+  private async requestOnce<T>({
+    path,
+    method,
+    params,
+    body,
+    headers = {},
+    responseType = 'json',
+  }: RequestOptions): Promise<T> {
+    await this.ensureAuthenticated(path);
+
+    const url = joinURL(this.config.baseUrl, this.config.path ?? '', path);
+    return ofetch<T>(url, {
+      method,
+      headers: {
+        ...this.authHeaders(),
+        ...headers,
+      },
+      body,
+      params,
+      retry: 0,
+      timeout: this.config.timeout,
+      responseType: responseType as 'json',
+      dispatcher: this.config.dispatcher,
+    });
   }
 
   private async checkVersion(): Promise<void> {
@@ -214,4 +259,14 @@ export class QBittorrentSession {
       };
     }
   }
+}
+
+function isAuthError(error: unknown): boolean {
+  const status =
+    typeof error === 'object' && error
+      ? ((error as { status?: unknown; statusCode?: unknown }).statusCode ??
+        (error as { status?: unknown; statusCode?: unknown }).status)
+      : undefined;
+
+  return status === 401 || status === 403;
 }

--- a/src/qbittorrentSession.ts
+++ b/src/qbittorrentSession.ts
@@ -182,6 +182,9 @@ export class QBittorrentSession {
       return { Authorization: `Bearer ${this.config.apiKey}` };
     }
 
+    // qBittorrent 5.2+ accepts Basic auth on regular API requests. Keep the
+    // SID cookie for older versions, but send Basic too so stale/missing cookies
+    // still work for clients configured with username/password.
     const headers: Record<string, string> = {
       Cookie: `${this.state.auth!.cookieName ?? 'SID'}=${this.state.auth!.sid ?? ''}`,
     };
@@ -206,6 +209,8 @@ export class QBittorrentSession {
     try {
       return await this.requestOnce<T>(options);
     } catch (error) {
+      // API key auth is stateless and cannot use /auth/login, so only cookie
+      // auth gets a one-shot re-login when the server rejects the session.
       if (this.config.apiKey || !isAuthError(error)) {
         throw error;
       }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -567,6 +567,28 @@ it('should be able to export and create from state', async () => {
   expect(client2.state.auth?.expires).toBeInstanceOf(Date);
 });
 
+it('should authenticate requests with basic auth when the session cookie is invalid', async () => {
+  const client = QBittorrent.createFromState(
+    { baseUrl, username, password },
+    {
+      auth: {
+        sid: 'invalid-session-id',
+        cookieName: 'QBT_SID_8080',
+        expires: new Date(Date.now() + 60_000).toISOString(),
+      },
+      version: {
+        version: 'v5.2.0',
+        isVersion5OrHigher: true,
+      },
+    },
+  );
+
+  const version = await client.getAppVersion();
+
+  expect(version).toBeTruthy();
+  expect(client.state.auth?.sid).toBe('invalid-session-id');
+});
+
 it('should list torrents', async () => {
   const client = new QBittorrent({ baseUrl, username, password });
   await setupTorrent(client);


### PR DESCRIPTION
qBittorrent 5.2+ can authenticate API requests with Basic auth when the session cookie is missing or stale. We were only sending the SID cookie after form login, so some newer qbit and seedbox setups could reject otherwise valid credentials.

Send Basic auth alongside cookie auth for username/password clients, keep API key auth separate, and retry once after auth failures by clearing stale session state.

CI now runs against the official qBittorrent alpha image so the real integration suite covers the newer WebAPI auth behavior instead of leaning on the old PPA fixture.