### PR TITLE
feat(api): Add new qBittorrent WebAPI endpoints

### DIFF
--- a/src/qbittorrent.ts
+++ b/src/qbittorrent.ts
@@ -1310,5 +1310,7 @@ export class QBittorrent extends QBittorrentSession implements TorrentClient {
 
 function serializeTorrentCreatorUrls(urls: string | string[]): string {
   const values = Array.isArray(urls) ? urls : urls.split('|');
+  // qBittorrent splits this field on `|`, then percent-decodes each entry with
+  // QUrl::fromPercentEncoding(). URLSearchParams handles the form body encoding.
   return values.map(url => encodeURIComponent(url)).join('|');
 }

--- a/src/qbittorrent.ts
+++ b/src/qbittorrent.ts
@@ -33,9 +33,14 @@ import type {
   Preferences,
   ProcessInfo,
   RotateApiKeyResponse,
+  RssAutoDownloadRule,
+  RssAutoDownloadRules,
   SyncMainData,
   Torrent,
   TorrentCategories,
+  TorrentCreatorAddTaskOptions,
+  TorrentCreatorAddTaskResponse,
+  TorrentCreatorTaskStatus,
   TorrentFile,
   TorrentFilePriority,
   TorrentFilters,
@@ -46,6 +51,7 @@ import type {
   TorrentPieceState,
   TorrentProperties,
   TorrentTrackers,
+  TransferSpeedLimits,
   UploadSpeed,
   WebSeed,
 } from './types.js';
@@ -127,6 +133,23 @@ export class QBittorrent extends QBittorrentSession implements TorrentClient {
       false,
     );
     return res;
+  }
+
+  /**
+   * Get free disk space at a path.
+   * Added in qBittorrent WebUI API v2.15.2.
+   * {@link https://github.com/qbittorrent/qBittorrent/pull/23856}
+   */
+  async getFreeSpaceAtPath(path: string): Promise<number> {
+    const res = await this.request<string>(
+      '/app/getFreeSpaceAtPath',
+      'GET',
+      { path },
+      undefined,
+      undefined,
+      false,
+    );
+    return Number(res);
   }
 
   /**
@@ -293,6 +316,31 @@ export class QBittorrent extends QBittorrentSession implements TorrentClient {
     };
 
     await this.request('/torrents/setUploadLimit', 'POST', undefined, objToUrlSearchParams(data));
+    return true;
+  }
+
+  /**
+   * Retrieve global and alternative speed limits.
+   * Added in qBittorrent WebUI API v2.16.0.
+   * {@link https://github.com/qbittorrent/qBittorrent/pull/24134}
+   */
+  async getTransferSpeedLimits(): Promise<TransferSpeedLimits> {
+    const res = await this.request<TransferSpeedLimits>('/transfer/getSpeedLimits', 'GET');
+    return res;
+  }
+
+  /**
+   * Set global and alternative speed limits.
+   * Added in qBittorrent WebUI API v2.16.0.
+   * {@link https://github.com/qbittorrent/qBittorrent/pull/24134}
+   */
+  async setTransferSpeedLimits(limits: TransferSpeedLimits): Promise<boolean> {
+    await this.request(
+      '/transfer/setSpeedLimits',
+      'POST',
+      undefined,
+      objToUrlSearchParams({ ...limits }),
+    );
     return true;
   }
 
@@ -499,6 +547,126 @@ export class QBittorrent extends QBittorrentSession implements TorrentClient {
   }
 
   /**
+   * Get RSS auto-download rules.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/src/webui/api/rsscontroller.cpp}
+   */
+  async getRssRules(): Promise<RssAutoDownloadRules> {
+    const res = await this.request<RssAutoDownloadRules>('/rss/rules', 'GET');
+    return res;
+  }
+
+  /**
+   * Create or update an RSS auto-download rule.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/src/webui/api/rsscontroller.cpp}
+   */
+  async setRssRule(ruleName: string, ruleDef: RssAutoDownloadRule): Promise<boolean> {
+    await this.request(
+      '/rss/setRule',
+      'POST',
+      undefined,
+      objToUrlSearchParams({
+        ruleName,
+        ruleDef: JSON.stringify(ruleDef),
+      }),
+    );
+    return true;
+  }
+
+  /**
+   * Clone an RSS auto-download rule.
+   * Added in qBittorrent WebUI API v2.15.4.
+   * {@link https://github.com/qbittorrent/qBittorrent/pull/24056}
+   */
+  async cloneRssRule(sourceName: string, cloneName: string): Promise<boolean> {
+    await this.request(
+      '/rss/cloneRule',
+      'POST',
+      undefined,
+      objToUrlSearchParams({ sourceName, cloneName }),
+    );
+    return true;
+  }
+
+  /**
+   * Remove an RSS auto-download rule.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/src/webui/api/rsscontroller.cpp}
+   */
+  async removeRssRule(ruleName: string): Promise<boolean> {
+    await this.request('/rss/removeRule', 'POST', undefined, objToUrlSearchParams({ ruleName }));
+    return true;
+  }
+
+  /**
+   * Add a torrent creation task.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/src/webui/api/torrentcreatorcontroller.cpp}
+   */
+  async addTorrentCreatorTask(
+    sourcePath: string,
+    options: TorrentCreatorAddTaskOptions = {},
+  ): Promise<TorrentCreatorAddTaskResponse> {
+    const { trackers, urlSeeds, ...rest } = options;
+    const params: Record<string, string | number | boolean> = { sourcePath };
+    for (const [key, value] of Object.entries(rest)) {
+      if (value !== undefined) {
+        params[key] = value;
+      }
+    }
+
+    if (trackers !== undefined) {
+      params.trackers = serializeTorrentCreatorUrls(trackers);
+    }
+
+    if (urlSeeds !== undefined) {
+      params.urlSeeds = serializeTorrentCreatorUrls(urlSeeds);
+    }
+
+    const res = await this.request<TorrentCreatorAddTaskResponse>(
+      '/torrentcreator/addTask',
+      'POST',
+      undefined,
+      objToUrlSearchParams(params),
+    );
+    return res;
+  }
+
+  /**
+   * Get torrent creation task status.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/src/webui/api/torrentcreatorcontroller.cpp}
+   */
+  async getTorrentCreatorStatus(taskID?: string): Promise<TorrentCreatorTaskStatus[]> {
+    const params = taskID ? { taskID } : undefined;
+    const res = await this.request<TorrentCreatorTaskStatus[]>(
+      '/torrentcreator/status',
+      'GET',
+      params,
+    );
+    return res;
+  }
+
+  /**
+   * Download a created .torrent file for a finished torrent creator task.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/src/webui/api/torrentcreatorcontroller.cpp}
+   */
+  async getTorrentCreatorFile(taskID: string): Promise<Uint8Array<ArrayBuffer>> {
+    const res = await this.requestArrayBuffer('/torrentcreator/torrentFile', { taskID });
+    return new Uint8Array(res);
+  }
+
+  /**
+   * Delete a torrent creation task.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/src/webui/api/torrentcreatorcontroller.cpp}
+   */
+  async deleteTorrentCreatorTask(taskID: string): Promise<boolean> {
+    await this.request(
+      '/torrentcreator/deleteTask',
+      'POST',
+      undefined,
+      objToUrlSearchParams({ taskID }),
+    );
+    return true;
+  }
+
+  /**
    * Fetch torrent metadata for a magnet URI, torrent hash, or .torrent URL.
    * Metadata retrieval can be asynchronous; a partial hash response means retry later.
    * Added in qBittorrent WebUI API v2.11.9.
@@ -551,6 +719,19 @@ export class QBittorrent extends QBittorrentSession implements TorrentClient {
    */
   async saveTorrentMetadata(source: string): Promise<Uint8Array<ArrayBuffer>> {
     const res = await this.requestArrayBuffer('/torrents/saveMetadata', { source });
+    return new Uint8Array(res);
+  }
+
+  /**
+   * Download a completed file from torrent content.
+   * Added in qBittorrent WebUI API v2.16.0.
+   * {@link https://github.com/qbittorrent/qBittorrent/pull/24135}
+   */
+  async downloadTorrentFile(hash: string, file: number | string): Promise<Uint8Array<ArrayBuffer>> {
+    const res = await this.requestArrayBuffer('/torrents/downloadFile', {
+      hash,
+      file: file.toString(),
+    });
     return new Uint8Array(res);
   }
 
@@ -1125,4 +1306,9 @@ export class QBittorrent extends QBittorrentSession implements TorrentClient {
     const res = await this.request<TorrentPeersResponse>('/sync/torrentPeers', 'GET', params);
     return res;
   }
+}
+
+function serializeTorrentCreatorUrls(urls: string | string[]): string {
+  const values = Array.isArray(urls) ? urls : urls.split('|');
+  return values.map(url => encodeURIComponent(url)).join('|');
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,6 +152,12 @@ export interface TorrentMetadataFile {
    * File size in bytes
    */
   length: number;
+  /**
+   * File priority when excluded file names apply.
+   * Added in qBittorrent WebUI API v2.16.0
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2160}
+   */
+  priority?: TorrentFilePriority;
 }
 
 export interface TorrentMetadataInfo {
@@ -1195,8 +1201,18 @@ export interface Preferences {
   mail_notification_smtp: string;
   /**
    * True if smtp server requires SSL connection
+   * @deprecated Removed in qBittorrent WebUI API v2.16.0. Use
+   * `mail_notification_encryption_type` instead.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2160}
    */
-  mail_notification_ssl_enabled: boolean;
+  mail_notification_ssl_enabled?: boolean;
+  /**
+   * SMTP encryption type for e-mail notifications.
+   * Added in qBittorrent WebUI API v2.16.0, replacing
+   * `mail_notification_ssl_enabled`.
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2160}
+   */
+  mail_notification_encryption_type?: string;
   /**
    * True if smtp server requires authentication
    */
@@ -1389,6 +1405,12 @@ export interface Preferences {
    * If true anonymous mode will be enabled; read more [here](https://github.com/qbittorrent/qBittorrent/wiki/Anonymous-Mode); this option is only available in qBittorent built against libtorrent version 0.16.X and higher
    */
   anonymous_mode: boolean;
+  /**
+   * Allow outgoing connections to peers while seeding.
+   * Added in qBittorrent WebUI API v2.16.0
+   * {@link https://github.com/qbittorrent/qBittorrent/blob/master/WebAPI_Changelog.md#2160}
+   */
+  seeding_outgoing_connections?: boolean;
   /**
    * See list of possible values here below
    */
@@ -1740,6 +1762,12 @@ export interface TorrentPeer {
   connection?: string;
   country?: string;
   country_code?: string;
+  /**
+   * How much of this peer's current progress was provided by this client.
+   * Added in qBittorrent WebUI API v2.16.0
+   * {@link https://github.com/qbittorrent/qBittorrent/pull/23989}
+   */
+  contribution?: number;
   dl_speed?: number;
   downloaded?: number;
   files?: string;
@@ -1769,6 +1797,115 @@ export type DownloadSpeed = Record<string, number>;
 
 export type UploadSpeed = Record<string, number>;
 
+export interface TransferSpeedLimits {
+  /**
+   * Global upload speed limit in bytes/second. `0` means unlimited.
+   */
+  up_limit: number;
+  /**
+   * Global download speed limit in bytes/second. `0` means unlimited.
+   */
+  dl_limit: number;
+  /**
+   * Alternative upload speed limit in bytes/second. `0` means unlimited.
+   */
+  alt_up_limit: number;
+  /**
+   * Alternative download speed limit in bytes/second. `0` means unlimited.
+   */
+  alt_dl_limit: number;
+}
+
+export interface RssAutoDownloadRule {
+  enabled?: boolean;
+  priority?: number;
+  useRegex?: boolean;
+  mustContain?: string;
+  mustNotContain?: string;
+  episodeFilter?: string;
+  affectedFeeds?: string[];
+  lastMatch?: string;
+  ignoreDays?: number;
+  smartFilter?: boolean;
+  previouslyMatchedEpisodes?: string[];
+  addPaused?: boolean | null;
+  contentLayout?: AddTorrentOptions['contentLayout'];
+  savePath?: string;
+  assignedCategory?: string;
+  torrentParams?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export type RssAutoDownloadRules = Record<string, RssAutoDownloadRule>;
+
+export interface TorrentCreatorAddTaskOptions {
+  comment?: string;
+  format?: 'v1' | 'v2' | 'hybrid';
+  /**
+   * Ignore dotfiles while creating the torrent.
+   * Added in qBittorrent WebUI API v2.16.0
+   * {@link https://github.com/qbittorrent/qBittorrent/pull/24346}
+   */
+  ignoreDotfiles?: boolean;
+  optimizeAlignment?: boolean;
+  paddedFileSizeLimit?: number;
+  pieceSize?: number;
+  private?: boolean;
+  source?: string;
+  startSeeding?: boolean;
+  torrentFilePath?: string;
+  trackers?: string | string[];
+  urlSeeds?: string | string[];
+}
+
+export interface TorrentCreatorAddTaskResponse {
+  taskID: string;
+}
+
+export type TorrentCreatorTaskStatusState = 'Queued' | 'Running' | 'Finished' | 'Failed';
+
+export interface TorrentCreatorTaskStatus {
+  taskID: string;
+  sourcePath: string;
+  pieceSize: number;
+  /**
+   * Whether dotfiles were ignored while creating the torrent.
+   * Added in qBittorrent WebUI API v2.16.0
+   * {@link https://github.com/qbittorrent/qBittorrent/pull/24346}
+   */
+  ignoreDotfiles?: boolean;
+  private: boolean;
+  /**
+   * Unix timestamp for when the task was added.
+   * Changed to a Unix timestamp in qBittorrent WebUI API v2.16.0
+   * {@link https://github.com/qbittorrent/qBittorrent/pull/24210}
+   */
+  timeAdded: number;
+  /**
+   * Unix timestamp for when the task started.
+   * Changed to a Unix timestamp in qBittorrent WebUI API v2.16.0
+   * {@link https://github.com/qbittorrent/qBittorrent/pull/24210}
+   */
+  timeStarted?: number;
+  /**
+   * Unix timestamp for when the task finished.
+   * Changed to a Unix timestamp in qBittorrent WebUI API v2.16.0
+   * {@link https://github.com/qbittorrent/qBittorrent/pull/24210}
+   */
+  timeFinished?: number;
+  status: TorrentCreatorTaskStatusState;
+  comment?: string;
+  errorMessage?: string;
+  format?: 'v1' | 'v2' | 'hybrid';
+  optimizeAlignment?: boolean;
+  paddedFileSizeLimit?: number;
+  progress?: number;
+  source?: string;
+  torrentFilePath?: string;
+  trackers?: string[];
+  urlSeeds?: string[];
+}
+
 export interface SyncMainData {
   /**
    * Response ID
@@ -1790,7 +1927,7 @@ export interface SyncMainData {
   categories_removed?: string[];
   tags?: string[];
   tags_removed?: string[];
-  server_state?: Record<string, unknown>;
+  server_state?: SyncServerState;
   /**
    * Tracker URLs grouped by tracker status
    * Added in qBittorrent WebUI API v2.13.0
@@ -1798,5 +1935,21 @@ export interface SyncMainData {
    */
   trackers?: Record<string, string[]>;
   trackers_removed?: string[];
+  [key: string]: unknown;
+}
+
+export interface SyncServerState {
+  /**
+   * Request latency metric.
+   * Added in qBittorrent WebUI API v2.16.0
+   * {@link https://github.com/qbittorrent/qBittorrent/pull/24152}
+   */
+  request_latency?: number;
+  /**
+   * Queued tracker announce count.
+   * Added in qBittorrent WebUI API v2.16.0
+   * {@link https://github.com/qbittorrent/qBittorrent/pull/24084}
+   */
+  queued_tracker_announces?: number;
   [key: string]: unknown;
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -241,6 +241,15 @@ it('should parse and save torrent metadata', async () => {
   const torrent = await client.saveTorrentMetadata(metadata!.hash);
   expect(torrent.byteLength).toBeGreaterThan(0);
 });
+it('should reject downloading incomplete torrent files through downloadFile endpoint', async () => {
+  if (await skipIfUnsupported('2.16.0', 'download torrent file')) {
+    return;
+  }
+
+  const client = new QBittorrent({ baseUrl, username, password });
+  const torrentId = await setupTorrent(client);
+  await expect(client.downloadTorrentFile(torrentId, 0)).rejects.toThrow();
+});
 it('should add torrent from parsed metadata with file priorities', async () => {
   if (await skipIfUnsupported('2.11.9', 'add torrent from parsed metadata')) {
     return;
@@ -455,6 +464,41 @@ it('should get process info', async () => {
   const processInfo = await client.getProcessInfo();
   expect(processInfo.launch_time).toBeGreaterThan(0);
 });
+it('should get free space at path', async () => {
+  if (await skipIfUnsupported('2.15.2', 'free space at path')) {
+    return;
+  }
+
+  const client = new QBittorrent({ baseUrl, username, password });
+  const freeSpace = await client.getFreeSpaceAtPath('/downloads');
+  expect(freeSpace).toBeGreaterThan(0);
+});
+it('should get and set transfer speed limits', async () => {
+  if (await skipIfUnsupported('2.16.0', 'transfer speed limits')) {
+    return;
+  }
+
+  const client = new QBittorrent({ baseUrl, username, password });
+  const original = await client.getTransferSpeedLimits();
+  try {
+    expect(
+      await client.setTransferSpeedLimits({
+        up_limit: 1024,
+        dl_limit: 2048,
+        alt_up_limit: 4096,
+        alt_dl_limit: 8192,
+      }),
+    ).toBe(true);
+    expect(await client.getTransferSpeedLimits()).toMatchObject({
+      up_limit: 1024,
+      dl_limit: 2048,
+      alt_up_limit: 4096,
+      alt_dl_limit: 8192,
+    });
+  } finally {
+    await client.setTransferSpeedLimits(original);
+  }
+});
 it('should get directory content metadata', async () => {
   if (await skipIfUnsupported('2.11.8', 'directory content metadata')) {
     return;
@@ -500,6 +544,58 @@ it('should store and load client data', async () => {
   await client.storeClientData({ test_value: 'stored' });
   const data = await client.loadClientData(['test_value']);
   expect(data.test_value).toBe('stored');
+});
+it('should clone rss auto-download rule', async () => {
+  if (await skipIfUnsupported('2.15.4', 'clone rss rule')) {
+    return;
+  }
+
+  const client = new QBittorrent({ baseUrl, username, password });
+  const sourceName = `source-${Date.now()}`;
+  const cloneName = `clone-${Date.now()}`;
+  try {
+    expect(
+      await client.setRssRule(sourceName, {
+        enabled: false,
+        mustContain: 'ubuntu',
+        savePath: '/downloads',
+      }),
+    ).toBe(true);
+    expect(await client.cloneRssRule(sourceName, cloneName)).toBe(true);
+
+    const rules = await client.getRssRules();
+    expect(rules[sourceName]?.mustContain).toBe('ubuntu');
+    expect(rules[cloneName]?.mustContain).toBe('ubuntu');
+  } finally {
+    await client.removeRssRule(sourceName);
+    await client.removeRssRule(cloneName);
+  }
+});
+it('should add, inspect, and delete torrent creator task', async () => {
+  if (await skipIfUnsupported('2.16.0', 'torrent creator task')) {
+    return;
+  }
+
+  const client = new QBittorrent({ baseUrl, username, password });
+  const missingSourcePath = `/downloads/missing-${Date.now()}`;
+  const { taskID } = await client.addTorrentCreatorTask(missingSourcePath, {
+    ignoreDotfiles: false,
+    private: true,
+    startSeeding: false,
+  });
+
+  try {
+    const [task] = await client.getTorrentCreatorStatus(taskID);
+    expect(task).toMatchObject({
+      taskID,
+      sourcePath: missingSourcePath,
+      ignoreDotfiles: false,
+      private: true,
+    });
+    expect(typeof task!.timeAdded).toBe('number');
+  } finally {
+    await client.deleteTorrentCreatorTask(taskID);
+  }
 });
 it('should get and set cookies', async () => {
   if (await skipIfUnsupported('2.11.3', 'cookies')) {
@@ -599,4 +695,18 @@ it('should list torrents', async () => {
   expect(typeof torrent.availability).toBe('number');
   expect(typeof torrent.force_start).toBe('boolean');
   expect(typeof torrent.seeding_time).toBe('number');
+});
+it('should include WebAPI 2.16 sync and preference fields when supported', async () => {
+  if (await skipIfUnsupported('2.16.0', 'WebAPI 2.16 fields')) {
+    return;
+  }
+
+  const client = new QBittorrent({ baseUrl, username, password });
+  const data = await client.getSyncMainData();
+  expect(typeof data.server_state?.request_latency).toBe('number');
+  expect(typeof data.server_state?.queued_tracker_announces).toBe('number');
+
+  const preferences = await client.getPreferences();
+  expect(typeof preferences.seeding_outgoing_connections).toBe('boolean');
+  expect(typeof preferences.mail_notification_encryption_type).toBe('string');
 });


### PR DESCRIPTION
Exposes the newer qBittorrent WebAPI bits we were missing: speed limits, free-space lookup, RSS rule cloning, torrent creator tasks, and torrent file downloads.

Also updates the 2.16 response types and adds version-gated integration coverage against the live qBittorrent test container.